### PR TITLE
Bitmasking custom fields values on edit ad

### DIFF
--- a/themes/default/views/oc-panel/profile/edit_ad.php
+++ b/themes/default/views/oc-panel/profile/edit_ad.php
@@ -251,7 +251,7 @@
                         <?endif?>
                         <!-- Fields coming from custom fields feature -->
                         <?if (Theme::get('premium')==1):?>
-                            <div id="custom-fields" data-customfield-values='<?=json_encode($ad->custom_columns())?>'>
+                            <div id="custom-fields" data-customfield-values='<?=json_encode($ad->custom_columns(), JSON_HEX_APOS, JSON_HEX_QUOT)?>'>
                                 <div id="custom-field-template" class="form-group hidden">
                                     <div class="col-sm-8">
                                         <div data-label></div>


### PR DESCRIPTION
Fixes issue https://bitbucket.org/neo22s/yclas/issues/431/custom-fields-disappear-on-update-ad