### PR TITLE
display expired ads on panel

### DIFF
--- a/themes/default/views/oc-panel/pages/ad.php
+++ b/themes/default/views/oc-panel/pages/ad.php
@@ -59,6 +59,19 @@
   </ul>
 </div>  
 
+<?if($current_url == Model_Ad::STATUS_PUBLISHED):?>
+	<div class="btn-group">
+	  <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+	    <?=Core::get('filter','Filter')?> <span class="caret"></span>
+	  </button>
+	  <ul class="dropdown-menu" role="menu">
+	    <?foreach($filters as $filter):?>
+		    <li><a class="ajax-load" href="<?=Route::url('oc-panel', array('controller'=> 'ad', 'action'=>'index')) ?>?status=1&filter=<?=$filter?>"><?=$filter?></a></li>
+	    <?endforeach?>
+	  </ul>
+	</div> 
+<?endif?>
+
 <br>
 <br>
 <div class="clearfix"></div>


### PR DESCRIPTION
https://github.com/open-classifieds/openclassifieds2/issues/1766

I have tested and it works, but I am not sure if it's the best way to do that.

A button to filter ads appears, only on when "All Ads" tab is selected. The options are All and Active and if expiration date > 0 there is a third option, Expired.

I will also include another option, Featured.