### PR TITLE
Missing JS captcha validation + 2.7.0. release blog post broken link

### DIFF
--- a/oc/config/versions.php
+++ b/oc/config/versions.php
@@ -4,7 +4,7 @@
   array (
     'codename' => 'Taipei',
     'released' => '2016-03-11',
-    'blog' => 'http://open-classifieds.com/2015/03/11/open-classifieds-2-7-0/',
+    'blog' => 'http://open-classifieds.com/2016/03/11/open-classifieds-2-7-0/',
     'changelog' => 'https://github.com/open-classifieds/openclassifieds2/compare/2.6.1...2.7.0',
     'issues' => 'https://github.com/open-classifieds/openclassifieds2/issues?q=milestone%3A2.7.0+is%3Aclosed',
     'download' => 'https://j.mp/oc_270',

--- a/themes/default/js/default.init.js
+++ b/themes/default/js/default.init.js
@@ -101,6 +101,10 @@ $(function(){
     $register_params['rules']['password1'] = {required: true};
     $register_params['rules']['password2'] = {required: true};
     $register_params['messages']['email'] = {"emaildomain" : $('.register :input[name="email"]').data('error')};
+    $register_params['rules']['captcha'] = {"remote" : {url: $(".register").attr('action'),
+                                                        type: "post",
+                                                        data: {ajaxValidateCaptcha: true}}};
+    $register_params['messages']['captcha'] = {"remote" : $('.register :input[name="captcha"]').data('error')};
 
     $(".register").each(function() {
         $(this).validate($register_params)


### PR DESCRIPTION
* Missing JS captcha validation on user registration, related to #1754
* Fixes 2.7.0. release blog post broken link