### PR TITLE
change label name

### DIFF
--- a/themes/default/views/oc-panel/pages/settings/payment.php
+++ b/themes/default/views/oc-panel/pages/settings/payment.php
@@ -397,7 +397,7 @@
                     </div>
 
                     <div class="form-group">
-                        <?= FORM::label($forms['paypal_seller']['key'], "<a target='_blank' href='https://docs.yclas.com/pay-directly-from-ad/'>".__('User paypal link')."</a>", array('class'=>'control-label col-sm-4', 'for'=>$forms['paypal_seller']['key']))?>
+                        <?= FORM::label($forms['paypal_seller']['key'], "<a target='_blank' href='https://docs.yclas.com/pay-directly-from-ad/'>".__('Buy Now button')."</a>", array('class'=>'control-label col-sm-4', 'for'=>$forms['paypal_seller']['key']))?>
                         <div class="col-sm-8">
                             <div class="onoffswitch">
                                 <?= FORM::hidden($forms['paypal_seller']['key'], 0);?>


### PR DESCRIPTION
Some days ago, in a discussion with Marco we agreed that users will be confused and it's hard for them to find how to activate Buy Now button, if they don't follow the right guide.