### PR TITLE
Fixes wrong anchor name on crud

### DIFF
--- a/themes/default/views/oc-panel/pages/categories/create.php
+++ b/themes/default/views/oc-panel/pages/categories/create.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 
-<h1 class="page-header page-title" id="crud-<?=__($name)?>">
+<h1 class="page-header page-title" id="crud-<?=$name?>">
     <?=__('New')?> <?=Text::ucfirst(__($name))?>
 </h1>
 <hr>

--- a/themes/default/views/oc-panel/pages/categories/update.php
+++ b/themes/default/views/oc-panel/pages/categories/update.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 <div class="page-header" id="crud-<?=$name?>">
-    <h1><?=__('Update')?> <?=Text::ucfirst($name)?></h1>
+    <h1><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
 </div>
 <div class="row">
     <div class="col-md-6">

--- a/themes/default/views/oc-panel/pages/categories/update.php
+++ b/themes/default/views/oc-panel/pages/categories/update.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
-<div class="page-header" id="crud-<?=__($name)?>">
-    <h1><?=__('Update')?> <?=Text::ucfirst(__($name))?></h1>
+<div class="page-header" id="crud-<?=$name?>">
+    <h1><?=__('Update')?> <?=Text::ucfirst($name)?></h1>
 </div>
 <div class="row">
     <div class="col-md-6">

--- a/themes/default/views/oc-panel/pages/locations/create.php
+++ b/themes/default/views/oc-panel/pages/locations/create.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 
-<h1 class="page-header page-title" id="crud-<?=__($name)?>">
+<h1 class="page-header page-title" id="crud-<?=$name?>">
     <?=__('New')?> <?=Text::ucfirst(__($name))?>
 </h1>
 

--- a/themes/default/views/oc-panel/pages/locations/update.php
+++ b/themes/default/views/oc-panel/pages/locations/update.php
@@ -1,6 +1,6 @@
 <?php defined('SYSPATH') or die('No direct script access.');?>
 
-<h1 class="page-header page-title">
+<h1 class="page-header page-title" id="crud-<?=$name?>">
     <?=__('Update')?> <?=Text::ucfirst(__($name))?>
 </h1>
 


### PR DESCRIPTION
Wrong anchor name when translation is distinct to English. We check anchor on https://github.com/open-classifieds/openclassifieds2/blob/master/themes/default/js/oc-panel/theme.init.js#L36